### PR TITLE
Add commented out module settings block.

### DIFF
--- a/config/Coldbox.cfc
+++ b/config/Coldbox.cfc
@@ -100,6 +100,13 @@
 		];
 
 		/*
+		// module setting overrides
+		moduleSettings = {
+			moduleName = {
+				settingName = "overrideValue"
+			}
+		};
+		
 		// flash scope configuration
 		flash = {
 			scope = "session,client,cluster,ColdboxCache,or full path",


### PR DESCRIPTION
This will prompt users that they can override module settings in their `config/ColdBox.cfc`.