### PR TITLE
Add coldbox mapping

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -18,7 +18,8 @@ component{
 	COLDBOX_CONFIG_FILE 	 = "";
 	// COLDBOX APPLICATION KEY OVERRIDE
 	COLDBOX_APP_KEY 		 = "";
-
+	this.mappings[ '/coldbox' ] = COLDBOX_APP_ROOT_PATH & 'coldbox/';
+	
 	// application start
 	public boolean function onApplicationStart(){
 		application.cbBootstrap = new coldbox.system.Bootstrap( COLDBOX_CONFIG_FILE, COLDBOX_APP_ROOT_PATH, COLDBOX_APP_KEY, COLDBOX_APP_MAPPING );


### PR DESCRIPTION
ColdBox throws a huge fit if you dont have this mapped, so we should add this to our template.

We should check the other templates.
I think it was not a requirement in ColdBox, but in 6.2.2 it blew up, line 87 of the bootstrap if you dont have a mapping.
Before we assumed it was in the root, right?